### PR TITLE
14 deleted messages should be soft deleted

### DIFF
--- a/CRUDTestProject/CRUDTestProject.csproj
+++ b/CRUDTestProject/CRUDTestProject.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="EasyCronJob.Core" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.11">

--- a/CRUDTestProject/Controllers/MessagesController.cs
+++ b/CRUDTestProject/Controllers/MessagesController.cs
@@ -100,6 +100,32 @@ namespace CRUDTestProject.Controllers
             return Ok();
         }
 
+        [HttpPatch]
+        [Authorize]
+        [Route("{id:guid}")]
+        public IActionResult RestoreMessage(Guid id)
+        {
+            var posterUsername = messageRepository.GetPosterUsernameById(id);
+            if (posterUsername != User.FindFirstValue(ClaimTypes.Name))
+            {
+                return Unauthorized("You can restore only your own posted messages.");
+            }
+            messageRepository.Restore(id);
+
+            return Ok();
+        }
+
+        [HttpGet]
+        [Authorize]
+        [Route("[action]")]
+        public IActionResult GetDeleted()
+        {
+            var messages = messageRepository.GetDeleted()
+                .Where(m => m.Username == User.FindFirstValue(ClaimTypes.Name));
+
+            return Ok(messages.Select(m => new MessageResponseModel(m)));
+        }
+
         [HttpGet]
         [Authorize]
         [Route("[action]")]

--- a/CRUDTestProject/Data/Entities/ISoftDeletable.cs
+++ b/CRUDTestProject/Data/Entities/ISoftDeletable.cs
@@ -1,0 +1,8 @@
+﻿namespace CRUDTestProject.Data.Entities
+{
+    public interface ISoftDeletable
+    {
+        public bool IsDeleted { get; set; }
+        public DateTime? DeletedOn { get; set; }
+    }
+}

--- a/CRUDTestProject/Data/Entities/Message.cs
+++ b/CRUDTestProject/Data/Entities/Message.cs
@@ -1,15 +1,18 @@
 ﻿namespace CRUDTestProject.Data.Entities
 {
-    public class Message
+    public class Message : ISoftDeletable
     {
         public Guid Id { get; set; }
         public required string Name { get; set; }
         public required string Content { get; set; }
-
         public required DateTime CreationDate { get; set; }
 
         //Data of the poster
         public required string Username { get; set; }
         public required string Email { get; set; }
+
+
+        public bool IsDeleted { get; set; }
+        public DateTime? DeletedOn { get; set; }
     }
 }

--- a/CRUDTestProject/Data/IMessageRepository.cs
+++ b/CRUDTestProject/Data/IMessageRepository.cs
@@ -4,17 +4,12 @@ namespace CRUDTestProject.Data
 {
     public interface IMessageRepository
     {
-        //returns all messages that haven't been deleted
-        IEnumerable<Message> GetAll();
-        IEnumerable<Message> GetDeleted();
-
+        IQueryable<Message> Messages { get; }
+        //Not to be tracked for changes
         Message? GetById(Guid id);
-
+        void Delete(Message message);
         void Insert(Message message);
-        Message Update(Guid id, string name, string content);
-        void Delete(Guid id);
-        void Restore(Guid id);
-
-        string? GetPosterUsernameById(Guid id);
+        void Restore(Message message);
+        void Update(Message message, string name, string content);
     }
 }

--- a/CRUDTestProject/Data/IMessageRepository.cs
+++ b/CRUDTestProject/Data/IMessageRepository.cs
@@ -4,13 +4,16 @@ namespace CRUDTestProject.Data
 {
     public interface IMessageRepository
     {
+        //returns all messages that haven't been deleted
         IEnumerable<Message> GetAll();
+        IEnumerable<Message> GetDeleted();
 
         Message? GetById(Guid id);
 
         void Insert(Message message);
         Message Update(Guid id, string name, string content);
         void Delete(Guid id);
+        void Restore(Guid id);
 
         string? GetPosterUsernameById(Guid id);
     }

--- a/CRUDTestProject/Data/MessageRepository.cs
+++ b/CRUDTestProject/Data/MessageRepository.cs
@@ -6,41 +6,17 @@ namespace CRUDTestProject.Data
 {
     public class MessageRepository(ApplicationDbContext dbContext) : IMessageRepository
     {
-        private IQueryable<Message> notDeleted => dbContext.Messages.Where(m => !m.IsDeleted);
-        private IQueryable<Message> deleted => dbContext.Messages.Where(m => m.IsDeleted);
+        public IQueryable<Message> Messages => dbContext.Messages;
 
-        public void Delete(Guid id)
+        public void Delete(Message message)
         {
-            var message = notDeleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for deletion.");
             dbContext.Messages.Remove(message);
             dbContext.SaveChanges();
         }
 
-        public IEnumerable<Message> GetAll()
-        {
-            return notDeleted.AsNoTracking();
-        }
-
         public Message? GetById(Guid id)
         {
-            return notDeleted.Where(m => m.Id == id).AsNoTracking().FirstOrDefault();
-        }
-
-        public IEnumerable<Message> GetDeleted()
-        {
-            return deleted.AsNoTracking();
-        }
-
-        public string? GetPosterUsernameById(Guid id)
-        {
-            var message = dbContext.Messages.Find(id);
-
-            if (message is not null)
-            {
-                return message.Username;
-            }
-
-            return null;
+            return Messages.Where(m => m.Id == id).AsNoTracking().FirstOrDefault();
         }
 
         public void Insert(Message message)
@@ -49,23 +25,19 @@ namespace CRUDTestProject.Data
             dbContext.SaveChanges();
         }
 
-        public void Restore(Guid id)
+        public void Restore(Message message)
         {
-            var message = deleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for restoration.");
             message.IsDeleted = false;
             message.DeletedOn = null;
             dbContext.SaveChanges();
         }
 
-        public Message Update(Guid id, string name, string content)
+        public void Update(Message message, string name, string content)
         {
-            var message = notDeleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for update.");
             message.Name = name;
             message.Content = content;
             
             dbContext.SaveChanges();
-
-            return message;
         }
     }
 }

--- a/CRUDTestProject/Data/MessageRepository.cs
+++ b/CRUDTestProject/Data/MessageRepository.cs
@@ -1,5 +1,4 @@
 ﻿using CRUDTestProject.Data.Entities;
-using CRUDTestProject.Middleware.Exceptions;
 using Microsoft.EntityFrameworkCore;
 
 namespace CRUDTestProject.Data

--- a/CRUDTestProject/Data/SoftDeleteInterceptor.cs
+++ b/CRUDTestProject/Data/SoftDeleteInterceptor.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using CRUDTestProject.Data.Entities;
+
+namespace CRUDTestProject.Data
+{
+    public class SoftDeleteInterceptor : SaveChangesInterceptor
+    {
+        public override InterceptionResult<int> SavingChanges(
+            DbContextEventData eventData,
+            InterceptionResult<int> result)
+        {
+            if (eventData.Context is null) return result;
+
+            foreach (var entry in eventData.Context.ChangeTracker
+                .Entries<ISoftDeletable>()
+                .Where(e => e.State == EntityState.Deleted))
+            {
+                entry.State = EntityState.Modified;
+                entry.Entity.IsDeleted = true;
+                entry.Entity.DeletedOn = DateTime.Now;
+            }
+
+            return result;
+        }
+    }
+}

--- a/CRUDTestProject/Data/SoftDeleteInterceptor.cs
+++ b/CRUDTestProject/Data/SoftDeleteInterceptor.cs
@@ -16,6 +16,8 @@ namespace CRUDTestProject.Data
                 .Entries<ISoftDeletable>()
                 .Where(e => e.State == EntityState.Deleted))
             {
+                if (entry.Entity.IsDeleted) continue;
+
                 entry.State = EntityState.Modified;
                 entry.Entity.IsDeleted = true;
                 entry.Entity.DeletedOn = DateTime.Now;

--- a/CRUDTestProject/Middleware/Exceptions/DifferentUserException.cs
+++ b/CRUDTestProject/Middleware/Exceptions/DifferentUserException.cs
@@ -1,0 +1,6 @@
+﻿namespace CRUDTestProject.Middleware.Exceptions
+{
+    public class DifferentUserException(string message) : Exception(message)
+    {
+    }
+}

--- a/CRUDTestProject/Middleware/GlobalExceptionHandler.cs
+++ b/CRUDTestProject/Middleware/GlobalExceptionHandler.cs
@@ -19,6 +19,10 @@ namespace CRUDTestProject.Middleware
                     problemDetails.Status = StatusCodes.Status404NotFound;
                     problemDetails.Title = exception.Message;
                     break;
+                case DifferentUserException:
+                    problemDetails.Status = StatusCodes.Status401Unauthorized;
+                    problemDetails.Title = exception.Message;
+                    break;
                 default:
                     problemDetails.Status = StatusCodes.Status500InternalServerError;
                     problemDetails.Title = "Unexpected error";

--- a/CRUDTestProject/Migrations/20250120113843_Add soft delete parameters.Designer.cs
+++ b/CRUDTestProject/Migrations/20250120113843_Add soft delete parameters.Designer.cs
@@ -4,6 +4,7 @@ using CRUDTestProject.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CRUDTestProject.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250120113843_Add soft delete parameters")]
+    partial class Addsoftdeleteparameters
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CRUDTestProject/Migrations/20250120113843_Add soft delete parameters.cs
+++ b/CRUDTestProject/Migrations/20250120113843_Add soft delete parameters.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CRUDTestProject.Migrations
+{
+    /// <inheritdoc />
+    public partial class Addsoftdeleteparameters : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedOn",
+                table: "Messages",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Messages",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedOn",
+                table: "Messages");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Messages");
+        }
+    }
+}

--- a/CRUDTestProject/Program.cs
+++ b/CRUDTestProject/Program.cs
@@ -1,5 +1,8 @@
+using Cronos;
 using CRUDTestProject.Data;
 using CRUDTestProject.Middleware;
+using CRUDTestProject.Scheduling;
+using EasyCronJob.Core;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -50,6 +53,13 @@ builder.Services.AddScoped<IMessageRepository, MessageRepository>();
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
+
+builder.Services.ApplyResulation<RemoveOldSoftDeletedMessages>(options => 
+{
+    options.CronExpression = "0 2 * * *"; // every day at 02:00 AM
+    options.TimeZoneInfo = TimeZoneInfo.Local;
+    options.CronFormat = Cronos.CronFormat.Standard;
+});
 
 var app = builder.Build();
 

--- a/CRUDTestProject/Program.cs
+++ b/CRUDTestProject/Program.cs
@@ -14,10 +14,13 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddSingleton<SoftDeleteInterceptor>();
 
 var connectionString = builder.Configuration.GetConnectionString("default");
-builder.Services.AddDbContext<ApplicationDbContext>(options =>
-    options.UseSqlServer(connectionString));
+builder.Services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =>
+    options
+    .UseSqlServer(connectionString)
+    .AddInterceptors(serviceProvider.GetRequiredService<SoftDeleteInterceptor>()));
 
 var configuration = builder.Configuration;
 // Adding Authentication
@@ -69,4 +72,4 @@ app.MapControllers();
 
 app.Run();
 
-public partial class Program {}
+public partial class Program { }

--- a/CRUDTestProject/Program.cs
+++ b/CRUDTestProject/Program.cs
@@ -2,6 +2,7 @@ using Cronos;
 using CRUDTestProject.Data;
 using CRUDTestProject.Middleware;
 using CRUDTestProject.Scheduling;
+using CRUDTestProject.Services;
 using EasyCronJob.Core;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
@@ -50,6 +51,7 @@ builder.Services.AddAuthentication(options =>
 });
 
 builder.Services.AddScoped<IMessageRepository, MessageRepository>();
+builder.Services.AddScoped<IMessageHandler, MessageHandler>();
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();

--- a/CRUDTestProject/Scheduling/RemoveOldSoftDeletedMessages.cs
+++ b/CRUDTestProject/Scheduling/RemoveOldSoftDeletedMessages.cs
@@ -1,0 +1,45 @@
+﻿using Cronos;
+using CRUDTestProject.Data;
+using EasyCronJob.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace CRUDTestProject.Scheduling
+{
+    public class RemoveOldSoftDeletedMessages(
+            ICronConfiguration<RemoveOldSoftDeletedMessages> cronConfiguration,
+            IServiceProvider serviceProvider,
+            ILogger<RemoveOldSoftDeletedMessages> logger) : CronJobService(cronConfiguration.CronExpression, cronConfiguration.TimeZoneInfo)
+    {
+        const int DAYS = 31;
+        public override Task StartAsync(CancellationToken cancellationToken)
+        {
+            logger.LogInformation($"Time: {DateTime.Now} the recurring job of removing old soft deleted messages is active");
+
+            return base.StartAsync(cancellationToken);
+        }
+
+        protected override Task ScheduleJob(CancellationToken cancellationToken)
+        {
+            logger.LogInformation($"Time: {DateTime.Now} scheduling next removal of soft deleted messages");
+            return base.ScheduleJob(cancellationToken);
+        }
+
+        public override Task DoWork(CancellationToken cancellationToken)
+        {
+            logger.LogInformation($"Removing messages that have been soft deleted for more than {DAYS} days. Start Time : {DateTime.Now}");
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+                DateTime removeBefore = DateTime.Now - TimeSpan.FromDays(DAYS);
+
+                var affected = dbContext.Messages.Where(m => m.IsDeleted)
+                                .Where(m => m.DeletedOn < removeBefore).ExecuteDelete();
+
+                logger.LogInformation("Removed: " + affected + " old soft deleted messages");
+            }
+            return base.DoWork(cancellationToken);
+        }
+    }
+}

--- a/CRUDTestProject/Scheduling/RemoveOldSoftDeletedMessages.cs
+++ b/CRUDTestProject/Scheduling/RemoveOldSoftDeletedMessages.cs
@@ -28,16 +28,25 @@ namespace CRUDTestProject.Scheduling
         public override Task DoWork(CancellationToken cancellationToken)
         {
             logger.LogInformation($"Removing messages that have been soft deleted for more than {DAYS} days. Start Time : {DateTime.Now}");
-            using (var scope = serviceProvider.CreateScope())
+            try
             {
-                var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                using (var scope = serviceProvider.CreateScope())
+                {
 
-                DateTime removeBefore = DateTime.Now - TimeSpan.FromDays(DAYS);
+                    var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-                var affected = dbContext.Messages.Where(m => m.IsDeleted)
-                                .Where(m => m.DeletedOn < removeBefore).ExecuteDelete();
+                    DateTime removeBefore = DateTime.Now - TimeSpan.FromDays(DAYS);
 
-                logger.LogInformation("Removed: " + affected + " old soft deleted messages");
+                    var affected = dbContext.Messages.Where(m => m.IsDeleted)
+                                    .Where(m => m.DeletedOn < removeBefore).ExecuteDelete();
+
+                    logger.LogInformation("Removed: " + affected + " old soft deleted messages");
+
+                }
+            }
+            catch (Exception e) 
+            {
+                logger.LogError(e, "Unexpected error in RemoveOldSoftDeletedMessages");
             }
             return base.DoWork(cancellationToken);
         }

--- a/CRUDTestProject/Services/IMessageHandler.cs
+++ b/CRUDTestProject/Services/IMessageHandler.cs
@@ -11,10 +11,8 @@ namespace CRUDTestProject.Services
         Message? GetById(Guid id);
 
         void Insert(Message message);
-        Message Update(Guid id, string name, string content);
-        void Delete(Guid id);
-        void Restore(Guid id);
-
-        string? GetPosterUsernameById(Guid id);
+        Message Update(Guid id, string name, string content, string username);
+        void Delete(Guid id, string username);
+        void Restore(Guid id, string username);
     }
 }

--- a/CRUDTestProject/Services/IMessageHandler.cs
+++ b/CRUDTestProject/Services/IMessageHandler.cs
@@ -1,0 +1,6 @@
+﻿namespace CRUDTestProject.Services
+{
+    public interface IMessageHandler
+    {
+    }
+}

--- a/CRUDTestProject/Services/IMessageHandler.cs
+++ b/CRUDTestProject/Services/IMessageHandler.cs
@@ -1,6 +1,20 @@
-﻿namespace CRUDTestProject.Services
+﻿using CRUDTestProject.Data.Entities;
+
+namespace CRUDTestProject.Services
 {
     public interface IMessageHandler
     {
+        //returns all messages that haven't been deleted
+        IEnumerable<Message> GetAll();
+        IEnumerable<Message> GetDeleted();
+
+        Message? GetById(Guid id);
+
+        void Insert(Message message);
+        Message Update(Guid id, string name, string content);
+        void Delete(Guid id);
+        void Restore(Guid id);
+
+        string? GetPosterUsernameById(Guid id);
     }
 }

--- a/CRUDTestProject/Services/MessageHandler.cs
+++ b/CRUDTestProject/Services/MessageHandler.cs
@@ -1,0 +1,6 @@
+﻿namespace CRUDTestProject.Services
+{
+    public class MessageHandler : IMessageHandler
+    {
+    }
+}

--- a/CRUDTestProject/Services/MessageHandler.cs
+++ b/CRUDTestProject/Services/MessageHandler.cs
@@ -10,9 +10,12 @@ namespace CRUDTestProject.Services
         private IQueryable<Message> notDeleted => repository.Messages.Where(m => !m.IsDeleted);
         private IQueryable<Message> deleted => repository.Messages.Where(m => m.IsDeleted);
 
-        public void Delete(Guid id)
+        public void Delete(Guid id, string username)
         {
-            var message = notDeleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for deletion.");
+            var message = notDeleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Message for deletion not found.");
+            
+            if (message.Username != username) throw new DifferentUserException("You can delete only your own messages.");
+            
             repository.Delete(message);
         }
 
@@ -31,33 +34,25 @@ namespace CRUDTestProject.Services
             return deleted.AsNoTracking();
         }
 
-        public string? GetPosterUsernameById(Guid id)
-        {
-            var message = repository.GetById(id);
-
-            if (message is not null)
-            {
-                return message.Username;
-            }
-
-            return null;
-        }
-
         public void Insert(Message message)
         {
             repository.Insert(message);
         }
 
-        public void Restore(Guid id)
+        public void Restore(Guid id, string username)
         {
-            var message = deleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for restoration.");
+            var message = deleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Message for restoration not found.");
+
+            if (message.Username != username) throw new DifferentUserException("You can restore only your own messages.");
 
             repository.Restore(message);
         }
 
-        public Message Update(Guid id, string name, string content)
+        public Message Update(Guid id, string name, string content, string username)
         {
-            var message = notDeleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for update.");
+            var message = notDeleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Message for update not found.");
+
+            if (message.Username != username) throw new DifferentUserException("You can update only your own messages.");
 
             repository.Update(message, name, content);
 

--- a/CRUDTestProject/Services/MessageHandler.cs
+++ b/CRUDTestProject/Services/MessageHandler.cs
@@ -1,6 +1,67 @@
-﻿namespace CRUDTestProject.Services
+﻿using CRUDTestProject.Data;
+using CRUDTestProject.Data.Entities;
+using CRUDTestProject.Middleware.Exceptions;
+using Microsoft.EntityFrameworkCore;
+
+namespace CRUDTestProject.Services
 {
-    public class MessageHandler : IMessageHandler
+    public class MessageHandler(IMessageRepository repository) : IMessageHandler
     {
+        private IQueryable<Message> notDeleted => repository.Messages.Where(m => !m.IsDeleted);
+        private IQueryable<Message> deleted => repository.Messages.Where(m => m.IsDeleted);
+
+        public void Delete(Guid id)
+        {
+            var message = notDeleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for deletion.");
+            repository.Delete(message);
+        }
+
+        public IEnumerable<Message> GetAll()
+        {
+            return notDeleted.AsNoTracking();
+        }
+
+        public Message? GetById(Guid id)
+        {
+            return notDeleted.Where(m => m.Id == id).AsNoTracking().FirstOrDefault();
+        }
+
+        public IEnumerable<Message> GetDeleted()
+        {
+            return deleted.AsNoTracking();
+        }
+
+        public string? GetPosterUsernameById(Guid id)
+        {
+            var message = repository.GetById(id);
+
+            if (message is not null)
+            {
+                return message.Username;
+            }
+
+            return null;
+        }
+
+        public void Insert(Message message)
+        {
+            repository.Insert(message);
+        }
+
+        public void Restore(Guid id)
+        {
+            var message = deleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for restoration.");
+
+            repository.Restore(message);
+        }
+
+        public Message Update(Guid id, string name, string content)
+        {
+            var message = notDeleted.Where(m => m.Id == id).FirstOrDefault() ?? throw new NotFoundException("Invalid message id for update.");
+
+            repository.Update(message, name, content);
+
+            return message;
+        }
     }
 }

--- a/MessagesTests/Controller/ControllerTests.cs
+++ b/MessagesTests/Controller/ControllerTests.cs
@@ -88,18 +88,6 @@ namespace MessagesTests.Controller
         }
 
         [Fact]
-        public void DeleteMessageOfSomeoneElse()
-        {
-            mockUserInController(fixture.message.Username + "notEmpty", string.Empty);
-
-            var response = controller.DeleteMessage(fixture.message.Id);
-
-            Assert.IsType<UnauthorizedObjectResult>(response);
-
-            fixture.Mock.Verify(m => m.Delete(It.IsAny<Guid>()), Times.Never);
-        }
-
-        [Fact]
         public void DeleteYourMessage()
         {
             mockUserInController(fixture.message.Username, string.Empty);
@@ -108,19 +96,7 @@ namespace MessagesTests.Controller
 
             Assert.IsType<OkResult>(response);
 
-            fixture.Mock.Verify(m => m.Delete(It.IsAny<Guid>()), Times.Once);
-        }
-
-        [Fact]
-        public void UpdateMessageOfSomeoneElse()
-        {
-            mockUserInController(fixture.message.Username + "notEmpty", string.Empty);
-
-            var response = controller.UpdateMessage(fixture.message.Id, new UpdateMessageDto() { Content = String.Empty, Name = String.Empty });
-
-            Assert.IsType<UnauthorizedObjectResult>(response);
-
-            fixture.Mock.Verify(m => m.Update(It.IsAny<Guid>(), string.Empty, string.Empty), Times.Never);
+            fixture.Mock.Verify(m => m.Delete(It.IsAny<Guid>(), fixture.message.Username), Times.Once);
         }
 
         [Fact]
@@ -132,7 +108,7 @@ namespace MessagesTests.Controller
 
             Assert.IsType<OkObjectResult>(response);
 
-            fixture.Mock.Verify(m => m.Update(It.IsAny<Guid>(), NAME, CONTENT), Times.Once);
+            fixture.Mock.Verify(m => m.Update(It.IsAny<Guid>(), NAME, CONTENT, fixture.message.Username), Times.Once);
 
             var result = response as OkObjectResult;
             Assert.Equal(StatusCodes.Status200OK, result.StatusCode);

--- a/MessagesTests/Controller/RepositoryFixture.cs
+++ b/MessagesTests/Controller/RepositoryFixture.cs
@@ -1,12 +1,12 @@
-﻿using CRUDTestProject.Data;
-using CRUDTestProject.Data.Entities;
+﻿using CRUDTestProject.Data.Entities;
+using CRUDTestProject.Services;
 using Moq;
 
 namespace MessagesTests.Controller
 {
     public class RepositoryFixture
     {
-        public Mock<IMessageRepository> Mock { get; private set; }
+        public Mock<IMessageHandler> Mock { get; private set; }
         public Guid ExistingId { get; private set; }
         public Guid MissingId { get; private set; }
 

--- a/MessagesTests/Controller/RepositoryFixture.cs
+++ b/MessagesTests/Controller/RepositoryFixture.cs
@@ -34,11 +34,9 @@ namespace MessagesTests.Controller
             
             Mock.Setup(repository => repository.Insert(It.IsAny<Message>()));
 
-            Mock.Setup(repository => repository.Delete(It.IsAny<Guid>()));
-
-            Mock.Setup(repository => repository.GetPosterUsernameById(ExistingId)).Returns(message.Name);
+            Mock.Setup(repository => repository.Delete(It.IsAny<Guid>(), It.IsAny<string>()));
             
-            Mock.Setup(repository => repository.Update(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>())).Returns(message);
+            Mock.Setup(repository => repository.Update(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(message);
         }
     }
 }

--- a/MessagesTests/Integration/CustomWebApplicationFactory.cs
+++ b/MessagesTests/Integration/CustomWebApplicationFactory.cs
@@ -21,8 +21,9 @@ namespace MessagesTests.Integration
                 services.RemoveAll(typeof(DbContextOptions<ApplicationDbContext>));
                 services.RemoveAll(typeof(DbConnection));
 
-                services.AddDbContext<ApplicationDbContext>(options =>
-                    options.UseInMemoryDatabase("TestDb"));
+                services.AddDbContext<ApplicationDbContext>((sp,options) =>
+                    options.UseInMemoryDatabase("TestDb")
+                    .AddInterceptors(sp.GetRequiredService<SoftDeleteInterceptor>()));
             });
         }
     }

--- a/MessagesTests/Services/HandlerTests.cs
+++ b/MessagesTests/Services/HandlerTests.cs
@@ -1,0 +1,76 @@
+﻿using CRUDTestProject.Data;
+using CRUDTestProject.Data.Entities;
+using CRUDTestProject.Middleware.Exceptions;
+using CRUDTestProject.Services;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace MessagesTests.Repository
+{
+    public class HandlerTests
+    {
+        private IMessageHandler handler;
+        Mock<IMessageRepository> mockRepository;
+
+        private List<Message> messages = [new() { Content = "Content", CreationDate = DateTime.Now, Email = "Email", Name = "Name", Username = "Username", Id = Guid.NewGuid() }];
+        private readonly Guid missingId = Guid.NewGuid();
+        public HandlerTests()
+        {
+            mockRepository = new();
+            
+            mockRepository.Setup(m => m.Messages).Returns(messages.AsQueryable());
+            mockRepository.Setup(m => m.GetById(messages[0].Id)).Returns(messages[0]);
+
+            handler = new MessageHandler(mockRepository.Object);
+        }
+
+        [Fact]
+        public void DeleteExisting() 
+        {
+            handler.Delete(messages[0].Id);
+
+            mockRepository.Verify(m => m.Delete(messages[0]), Times.Once);
+        }
+
+        [Fact]
+        public void DeleteMissing()
+        {
+            Assert.Throws<NotFoundException>(() => handler.Delete(missingId));
+        }
+
+        [Fact]
+        public void UpdateExisting()
+        {
+            const string updatedContent = "upContent";
+            const string updatedName = "upName";
+            var result = handler.Update(messages[0].Id, updatedName, updatedContent);
+
+            mockRepository.Verify(m => m.Update(messages[0], updatedName, updatedContent), Times.Once);
+        }
+
+        [Fact]
+        public void UpdateMissing()
+        {
+            const string updatedContent = "upContent";
+            const string updatedName = "upName";
+            
+            Assert.Throws<NotFoundException>(() => handler.Update(missingId, updatedName, updatedContent));
+        }
+
+        [Fact]
+        public void GetPosterUsernameByExistingId()
+        {
+            var result = handler.GetPosterUsernameById(messages[0].Id);
+
+            Assert.Equal(messages[0].Username, result);
+        }
+
+        [Fact]
+        public void GetPosterUsernameByMissingId()
+        {
+            var result = handler.GetPosterUsernameById(missingId);
+
+            Assert.Null(result);
+        }
+    }
+}


### PR DESCRIPTION
##Changes
-added soft delete for messages
-added a background job that runs once a day at 02;00 AM local time and removes old soft deleted messages
-deleting a soft deleted message fully deletes it
-added restoring end viewing of soft deleted messages
-added a handler for the messages
##Notes
-added a handler for the messages to remove business logic from the repository
##Unit Tests
-added coverage
-added integration tests for getting and restoring soft deleted messages
##Logs and Screenshots
-entity in SQL server
![image](https://github.com/user-attachments/assets/9f983163-4db4-4604-8a9f-58e1559d99d3)
-response from get deleted :
```
 [
    {
        "id": "0c8157ec-bf16-40c2-470c-08dd3a064f24",
        "name": "playing",
        "content": "chess960",
        "creationDate": "2025-01-21T12:28:12.8146908",
        "username": "Garry"
    }
]
```
-logs for scheduling the background job : 
```
info: CRUDTestProject.Scheduling.RemoveOldSoftDeletedMessages[0]
      Time: 1/21/2025 5:14:27 PM the recurring job of removing old soft deleted messages is active
info: CRUDTestProject.Scheduling.RemoveOldSoftDeletedMessages[0]
      Time: 1/21/2025 5:14:27 PM scheduling next removal of soft deleted messages
```
-after patch
![image](https://github.com/user-attachments/assets/f71ae363-1bc6-4f63-a276-3c28602fa98c)
