### PR TITLE
16 a filter for bad words

### DIFF
--- a/CRUDTestProject.sln
+++ b/CRUDTestProject.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessagesTests", "MessagesTe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ManagementTests", "ManagementTests\ManagementTests.csproj", "{024C63E9-EFAB-431A-B107-EA38C0D75DCE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedLibrary", "SharedLibrary\SharedLibrary.csproj", "{32C02F99-0B86-4A66-AA2A-4C199D3120E6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{024C63E9-EFAB-431A-B107-EA38C0D75DCE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{024C63E9-EFAB-431A-B107-EA38C0D75DCE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{024C63E9-EFAB-431A-B107-EA38C0D75DCE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32C02F99-0B86-4A66-AA2A-4C199D3120E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32C02F99-0B86-4A66-AA2A-4C199D3120E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32C02F99-0B86-4A66-AA2A-4C199D3120E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32C02F99-0B86-4A66-AA2A-4C199D3120E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CRUDTestProject/CRUDTestProject.csproj
+++ b/CRUDTestProject/CRUDTestProject.csproj
@@ -25,4 +25,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\SharedLibrary\SharedLibrary.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/CRUDTestProject/Controllers/BadWordsController.cs
+++ b/CRUDTestProject/Controllers/BadWordsController.cs
@@ -1,0 +1,29 @@
+﻿using CRUDTestProject.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections;
+
+namespace CRUDTestProject.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class BadWordsController(IBadWordsHandler handler) : ControllerBase
+    {
+        [HttpPost]
+        [Authorize(Roles = "Admin")]
+        public IActionResult AddBadWords(IEnumerable<string> badWords)
+        {
+            handler.AddRange(badWords);
+            return Ok();
+        }
+
+        [HttpDelete]
+        [Authorize(Roles = "Admin")]
+        public IActionResult RemoveBadWord(string badWord)
+        {
+            handler.Remove(badWord);
+            return Ok();
+        }
+    }
+}

--- a/CRUDTestProject/Data/ApplicationDbContext.cs
+++ b/CRUDTestProject/Data/ApplicationDbContext.cs
@@ -6,5 +6,6 @@ namespace CRUDTestProject.Data
     public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : DbContext(options)
     {
         public DbSet<Message> Messages { get; set; }
+        public DbSet<BadWord> BadWords { get; set; }
     }
 }

--- a/CRUDTestProject/Data/Entities/BadWord.cs
+++ b/CRUDTestProject/Data/Entities/BadWord.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace CRUDTestProject.Data.Entities
+{
+    public class BadWord
+    {
+        [Key]
+        public required string Word { get; set; }
+    }
+}

--- a/CRUDTestProject/Data/Entities/Message.cs
+++ b/CRUDTestProject/Data/Entities/Message.cs
@@ -1,14 +1,24 @@
-﻿namespace CRUDTestProject.Data.Entities
+﻿using SharedLibrary;
+using System.ComponentModel.DataAnnotations;
+
+namespace CRUDTestProject.Data.Entities
 {
     public class Message : ISoftDeletable
     {
         public Guid Id { get; set; }
+
+        [MaxLength(Constants.MessageNameMaxLength)]
         public required string Name { get; set; }
+        
+        [MaxLength(Constants.MessageContentMaxLength)]
         public required string Content { get; set; }
         public required DateTime CreationDate { get; set; }
 
         //Data of the poster
+        [MaxLength(Constants.UsernameMaxLength)]
         public required string Username { get; set; }
+        
+        [MaxLength(Constants.EmailMaxLength)]
         public required string Email { get; set; }
 
 

--- a/CRUDTestProject/Data/Repositories/BadWordsRepository.cs
+++ b/CRUDTestProject/Data/Repositories/BadWordsRepository.cs
@@ -1,0 +1,22 @@
+﻿using CRUDTestProject.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CRUDTestProject.Data.Repositories
+{
+    public class BadWordsRepository(ApplicationDbContext dbContext) : IBadWordsRepository
+    {
+        public IEnumerable<BadWord> BadWords => dbContext.BadWords.AsNoTracking();
+
+        public void AddRange(IEnumerable<BadWord> badWords)
+        {
+            dbContext.BadWords.AddRange(badWords);
+            dbContext.SaveChanges();
+        }
+
+        public void Remove(BadWord badWord)
+        {
+            dbContext.BadWords.Remove(badWord);
+            dbContext.SaveChanges();
+        }
+    }
+}

--- a/CRUDTestProject/Data/Repositories/IBadWordsRepository.cs
+++ b/CRUDTestProject/Data/Repositories/IBadWordsRepository.cs
@@ -1,0 +1,11 @@
+﻿using CRUDTestProject.Data.Entities;
+
+namespace CRUDTestProject.Data.Repositories
+{
+    public interface IBadWordsRepository
+    {
+        IEnumerable<BadWord> BadWords { get; }
+        void AddRange(IEnumerable<BadWord> badWords);
+        void Remove(BadWord badWord);
+    }
+}

--- a/CRUDTestProject/Data/Repositories/IMessageRepository.cs
+++ b/CRUDTestProject/Data/Repositories/IMessageRepository.cs
@@ -1,6 +1,6 @@
 ﻿using CRUDTestProject.Data.Entities;
 
-namespace CRUDTestProject.Data
+namespace CRUDTestProject.Data.Repositories
 {
     public interface IMessageRepository
     {

--- a/CRUDTestProject/Data/Repositories/MessageRepository.cs
+++ b/CRUDTestProject/Data/Repositories/MessageRepository.cs
@@ -1,7 +1,7 @@
 ﻿using CRUDTestProject.Data.Entities;
 using Microsoft.EntityFrameworkCore;
 
-namespace CRUDTestProject.Data
+namespace CRUDTestProject.Data.Repositories
 {
     public class MessageRepository(ApplicationDbContext dbContext) : IMessageRepository
     {
@@ -35,7 +35,7 @@ namespace CRUDTestProject.Data
         {
             message.Name = name;
             message.Content = content;
-            
+
             dbContext.SaveChanges();
         }
     }

--- a/CRUDTestProject/Middleware/Exceptions/BadWordException.cs
+++ b/CRUDTestProject/Middleware/Exceptions/BadWordException.cs
@@ -1,0 +1,6 @@
+﻿namespace CRUDTestProject.Middleware.Exceptions
+{
+    public class BadWordException(string message) : Exception(message)
+    {
+    }
+}

--- a/CRUDTestProject/Middleware/GlobalExceptionHandler.cs
+++ b/CRUDTestProject/Middleware/GlobalExceptionHandler.cs
@@ -23,6 +23,10 @@ namespace CRUDTestProject.Middleware
                     problemDetails.Status = StatusCodes.Status401Unauthorized;
                     problemDetails.Title = exception.Message;
                     break;
+                case BadWordException:
+                    problemDetails.Status = StatusCodes.Status406NotAcceptable;
+                    problemDetails.Title = exception.Message;
+                    break;
                 default:
                     problemDetails.Status = StatusCodes.Status500InternalServerError;
                     problemDetails.Title = "Unexpected error";

--- a/CRUDTestProject/Migrations/20250122154215_addingbadwords.Designer.cs
+++ b/CRUDTestProject/Migrations/20250122154215_addingbadwords.Designer.cs
@@ -4,6 +4,7 @@ using CRUDTestProject.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CRUDTestProject.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250122154215_addingbadwords")]
+    partial class addingbadwords
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CRUDTestProject/Migrations/20250122154215_addingbadwords.cs
+++ b/CRUDTestProject/Migrations/20250122154215_addingbadwords.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CRUDTestProject.Migrations
+{
+    /// <inheritdoc />
+    public partial class addingbadwords : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BadWords",
+                columns: table => new
+                {
+                    Word = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BadWords", x => x.Word);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BadWords");
+        }
+    }
+}

--- a/CRUDTestProject/Migrations/20250124091511_adjustmaxlengthofcolumns.Designer.cs
+++ b/CRUDTestProject/Migrations/20250124091511_adjustmaxlengthofcolumns.Designer.cs
@@ -4,6 +4,7 @@ using CRUDTestProject.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CRUDTestProject.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250124091511_adjustmaxlengthofcolumns")]
+    partial class adjustmaxlengthofcolumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CRUDTestProject/Migrations/20250124091511_adjustmaxlengthofcolumns.cs
+++ b/CRUDTestProject/Migrations/20250124091511_adjustmaxlengthofcolumns.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CRUDTestProject.Migrations
+{
+    /// <inheritdoc />
+    public partial class adjustmaxlengthofcolumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "Messages",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Messages",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Messages",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Content",
+                table: "Messages",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "Messages",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Messages",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Messages",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Content",
+                table: "Messages",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1000)",
+                oldMaxLength: 1000);
+        }
+    }
+}

--- a/CRUDTestProject/Models/AddMessageDto.cs
+++ b/CRUDTestProject/Models/AddMessageDto.cs
@@ -1,8 +1,14 @@
-﻿namespace CRUDTestProject.Models
+﻿using SharedLibrary;
+using System.ComponentModel.DataAnnotations;
+
+namespace CRUDTestProject.Models
 {
     public class AddMessageDto
     {
+        [MaxLength(Constants.MessageNameMaxLength)]
         public required string Name { get; set; }
+
+        [MaxLength(Constants.MessageContentMaxLength)]
         public required string Content { get; set; }
     }
 }

--- a/CRUDTestProject/Models/UpdateMessageDto.cs
+++ b/CRUDTestProject/Models/UpdateMessageDto.cs
@@ -1,8 +1,14 @@
-﻿namespace CRUDTestProject.Models
+﻿using SharedLibrary;
+using System.ComponentModel.DataAnnotations;
+
+namespace CRUDTestProject.Models
 {
     public class UpdateMessageDto
     {
+        [MaxLength(Constants.MessageNameMaxLength)]
         public required string Name { get; set; }
+
+        [MaxLength(Constants.MessageContentMaxLength)]
         public required string Content { get; set; }
     }
 }

--- a/CRUDTestProject/Program.cs
+++ b/CRUDTestProject/Program.cs
@@ -1,5 +1,6 @@
 using Cronos;
 using CRUDTestProject.Data;
+using CRUDTestProject.Data.Repositories;
 using CRUDTestProject.Middleware;
 using CRUDTestProject.Scheduling;
 using CRUDTestProject.Services;
@@ -52,6 +53,8 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddScoped<IMessageRepository, MessageRepository>();
 builder.Services.AddScoped<IMessageHandler, MessageHandler>();
+builder.Services.AddScoped<IBadWordsRepository, BadWordsRepository>();
+builder.Services.AddScoped<IBadWordsHandler, BadWordsHandler>();
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();

--- a/CRUDTestProject/Services/BadWordsHandler.cs
+++ b/CRUDTestProject/Services/BadWordsHandler.cs
@@ -1,5 +1,6 @@
 ﻿using CRUDTestProject.Data.Entities;
 using CRUDTestProject.Data.Repositories;
+using CRUDTestProject.Middleware.Exceptions;
 
 namespace CRUDTestProject.Services
 {
@@ -7,7 +8,8 @@ namespace CRUDTestProject.Services
     {
         public void AddRange(IEnumerable<string> badWords)
         {
-            repository.AddRange(badWords.Select(w => new BadWord() { Word = w }));
+            var toAdd = badWords.Where(w => repository.BadWords.FirstOrDefault(bw => bw.Word == w) is null);
+            repository.AddRange(toAdd.Select(w => new BadWord() { Word = w })); 
         }
 
         public void CheckForBadWords(IEnumerable<string> toCheck)
@@ -16,14 +18,15 @@ namespace CRUDTestProject.Services
             {
                 foreach (var item in toCheck)
                 {
-                    if (item.Contains(badWord.Word)) throw new Exception($"{badWord} is a bad word!");
+                    if (item.Contains(badWord.Word)) throw new BadWordException($"{badWord.Word} is a bad word!");
                 }
             }
         }
 
         public void Remove(string badWord)
         {
-            repository.Remove(new() { Word = badWord });
+            var toRemove = repository.BadWords.FirstOrDefault(w => w.Word == badWord) ?? throw new NotFoundException("Bad word for removal not found.");
+            repository.Remove(toRemove);
         }
     }
 }

--- a/CRUDTestProject/Services/BadWordsHandler.cs
+++ b/CRUDTestProject/Services/BadWordsHandler.cs
@@ -1,0 +1,29 @@
+﻿using CRUDTestProject.Data.Entities;
+using CRUDTestProject.Data.Repositories;
+
+namespace CRUDTestProject.Services
+{
+    public class BadWordsHandler(IBadWordsRepository repository) : IBadWordsHandler
+    {
+        public void AddRange(IEnumerable<string> badWords)
+        {
+            repository.AddRange(badWords.Select(w => new BadWord() { Word = w }));
+        }
+
+        public void CheckForBadWords(IEnumerable<string> toCheck)
+        {
+            foreach (var badWord in repository.BadWords)
+            {
+                foreach (var item in toCheck)
+                {
+                    if (item.Contains(badWord.Word)) throw new Exception($"{badWord} is a bad word!");
+                }
+            }
+        }
+
+        public void Remove(string badWord)
+        {
+            repository.Remove(new() { Word = badWord });
+        }
+    }
+}

--- a/CRUDTestProject/Services/IBadWordsHandler.cs
+++ b/CRUDTestProject/Services/IBadWordsHandler.cs
@@ -1,0 +1,12 @@
+﻿using CRUDTestProject.Data.Entities;
+
+namespace CRUDTestProject.Services
+{
+    public interface IBadWordsHandler
+    {
+        //throws if there is a bad word
+        void CheckForBadWords(IEnumerable<string> toCheck);
+        void AddRange(IEnumerable<string> badWords);
+        void Remove(string badWord);
+    }
+}

--- a/CRUDTestProject/Services/MessageHandler.cs
+++ b/CRUDTestProject/Services/MessageHandler.cs
@@ -1,11 +1,11 @@
-﻿using CRUDTestProject.Data;
-using CRUDTestProject.Data.Entities;
+﻿using CRUDTestProject.Data.Entities;
+using CRUDTestProject.Data.Repositories;
 using CRUDTestProject.Middleware.Exceptions;
 using Microsoft.EntityFrameworkCore;
 
 namespace CRUDTestProject.Services
 {
-    public class MessageHandler(IMessageRepository repository) : IMessageHandler
+    public class MessageHandler(IMessageRepository repository, IBadWordsHandler badWordsHandler) : IMessageHandler
     {
         private IQueryable<Message> notDeleted => repository.Messages.Where(m => !m.IsDeleted);
         private IQueryable<Message> deleted => repository.Messages.Where(m => m.IsDeleted);
@@ -36,6 +36,7 @@ namespace CRUDTestProject.Services
 
         public void Insert(Message message)
         {
+            badWordsHandler.CheckForBadWords([message.Name, message.Content]);
             repository.Insert(message);
         }
 

--- a/ManagementTests/Services/UserHandlerTests.cs
+++ b/ManagementTests/Services/UserHandlerTests.cs
@@ -25,6 +25,7 @@ namespace ManagementTests.Services
             var user = new User() { TenantId = "", Email = "", UserName = USERNAME };
             mockManager.Setup(m => m.FindByNameAsync(USERNAME)).ReturnsAsync(user);
             mockManager.Setup(m => m.CheckPasswordAsync(user, PASSWORD)).ReturnsAsync(true);
+            mockManager.Setup(m => m.GetRolesAsync(user)).ReturnsAsync([]);
 
             mockManager.Setup(m => m.CreateAsync(It.IsAny<User>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
             

--- a/ManagementTests/Services/UserHandlerTests.cs
+++ b/ManagementTests/Services/UserHandlerTests.cs
@@ -25,7 +25,7 @@ namespace ManagementTests.Services
             var user = new User() { TenantId = "", Email = "", UserName = USERNAME };
             mockManager.Setup(m => m.FindByNameAsync(USERNAME)).ReturnsAsync(user);
             mockManager.Setup(m => m.CheckPasswordAsync(user, PASSWORD)).ReturnsAsync(true);
-            mockManager.Setup(m => m.GetRolesAsync(user)).ReturnsAsync([]);
+            mockManager.Setup(m => m.GetRolesAsync(user)).ReturnsAsync(["Admin"]);
 
             mockManager.Setup(m => m.CreateAsync(It.IsAny<User>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
             
@@ -43,6 +43,7 @@ namespace ManagementTests.Services
             var token = await userHandler.Authenticate(new LoginUserModel() { Password = PASSWORD, Username = USERNAME });
 
             Assert.Equal(USERNAME, token.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Name).Value);
+            Assert.Contains(token.Claims, c => c.Type == ClaimTypes.Role && c.Value == "Admin");
         }
 
         [Fact]

--- a/Managment/Management.csproj
+++ b/Managment/Management.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\SharedLibrary\SharedLibrary.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Managment/Models/LoginUserModel.cs
+++ b/Managment/Models/LoginUserModel.cs
@@ -1,7 +1,11 @@
-﻿namespace Management.Models
+﻿using SharedLibrary;
+using System.ComponentModel.DataAnnotations;
+
+namespace Management.Models
 {
     public class LoginUserModel
     {
+        [MaxLength(Constants.UsernameMaxLength)]
         public required string Username { get; set; }
         public required string Password { get; set; }
 

--- a/Managment/Models/RegisterUserModel.cs
+++ b/Managment/Models/RegisterUserModel.cs
@@ -1,9 +1,15 @@
-﻿namespace Management.Models
+﻿
+using SharedLibrary;
+using System.ComponentModel.DataAnnotations;
+
+namespace Management.Models
 {
     public class RegisterUserModel
     {
+        [MaxLength(Constants.UsernameMaxLength)]
         public required string Username { get; set; }
         public required string Password { get; set; }
+        [MaxLength(Constants.EmailMaxLength)]
         public required string Email { get; set; }
         public required string TenantId { get; set; }
     }

--- a/Managment/Services/UserHandler.cs
+++ b/Managment/Services/UserHandler.cs
@@ -26,6 +26,11 @@ namespace Management.Services
                     new(ClaimTypes.Email, user.Email),
                     new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
                 };
+            var roles = await userManager.GetRolesAsync(user);
+            foreach (var role in roles)
+            {
+                authClaims.Add(new(ClaimTypes.Role, role));
+            }
 
             return GetToken(authClaims);
         }

--- a/MessagesTests/Repository/MessageRepositoryTests.cs
+++ b/MessagesTests/Repository/MessageRepositoryTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace MessagesTests.Repository
 {
-    public class RepositoryTests
+    public class MessageRepositoryTests
     {
         private IMessageRepository repository;
         private DbContextOptions<ApplicationDbContext> options;
@@ -15,7 +15,7 @@ namespace MessagesTests.Repository
         private Message message = new() { Content = "Content", CreationDate = DateTime.Now, Email = "Email", Name = "Name", Username = "Username", Id = Guid.NewGuid() };
         private Message toRestore = new() { Content = "Content", CreationDate = DateTime.Now.AddDays(-5), Email = "Email", Name = "Name", Username = "Username", Id = Guid.NewGuid() , DeletedOn = DateTime.Now, IsDeleted = true};
         private readonly Guid missingId = Guid.NewGuid();
-        public RepositoryTests()
+        public MessageRepositoryTests()
         {
 
             options = new DbContextOptionsBuilder<ApplicationDbContext>()

--- a/MessagesTests/Repository/RepositoryTests.cs
+++ b/MessagesTests/Repository/RepositoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using CRUDTestProject.Data;
 using CRUDTestProject.Data.Entities;
+using CRUDTestProject.Data.Repositories;
 using CRUDTestProject.Middleware.Exceptions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/MessagesTests/Services/BadWordsHandlerTests.cs
+++ b/MessagesTests/Services/BadWordsHandlerTests.cs
@@ -1,0 +1,51 @@
+﻿using CRUDTestProject.Data.Entities;
+using CRUDTestProject.Data.Repositories;
+using CRUDTestProject.Middleware.Exceptions;
+using CRUDTestProject.Services;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MessagesTests.Services
+{
+    public class BadWordsHandlerTests
+    {
+        private IBadWordsHandler handler;
+        private Mock<IBadWordsRepository> mockRepository;
+        IEnumerable<BadWord> badWords;
+        const string BADWORD = "BADDDDDDDDDDDDDDDDDD";
+        private readonly string MISSING = Guid.NewGuid().ToString();
+        public BadWordsHandlerTests()
+        {
+            badWords = [new() { Word = BADWORD}];
+            mockRepository = new();
+
+            mockRepository.Setup(m => m.BadWords).Returns(badWords);
+
+            handler = new BadWordsHandler(mockRepository.Object);
+        }
+
+        [Fact]
+        public void CheckForBadWordsShouldThrowOnBadWord() 
+        {
+            Assert.Throws<BadWordException>(() => handler.CheckForBadWords([BADWORD]));
+        }
+
+        [Fact]
+        public void RemoveMissing()
+        {
+            Assert.Throws<NotFoundException>(() => handler.Remove(MISSING));
+        }
+
+        [Fact]
+        public void RemoveExisting()
+        {
+            handler.Remove(BADWORD);
+
+            mockRepository.Verify(m => m.Remove(It.IsAny<BadWord>()), Times.Once);
+        }
+    }
+}

--- a/MessagesTests/Services/HandlerTests.cs
+++ b/MessagesTests/Services/HandlerTests.cs
@@ -1,5 +1,5 @@
-﻿using CRUDTestProject.Data;
-using CRUDTestProject.Data.Entities;
+﻿using CRUDTestProject.Data.Entities;
+using CRUDTestProject.Data.Repositories;
 using CRUDTestProject.Middleware.Exceptions;
 using CRUDTestProject.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -23,7 +23,7 @@ namespace MessagesTests.Repository
             mockRepository.Setup(m => m.Messages).Returns(messages.AsQueryable());
             mockRepository.Setup(m => m.GetById(messages[0].Id)).Returns(messages[0]);
 
-            handler = new MessageHandler(mockRepository.Object);
+            handler = new MessageHandler(mockRepository.Object, Mock.Of<IBadWordsHandler>());
         }
 
         [Fact]

--- a/MessagesTests/Services/MessageHandlerTests.cs
+++ b/MessagesTests/Services/MessageHandlerTests.cs
@@ -8,22 +8,42 @@ using Moq;
 
 namespace MessagesTests.Repository
 {
-    public class HandlerTests
+    public class MessageHandlerTests
     {
         private IMessageHandler handler;
         Mock<IMessageRepository> mockRepository;
+        Mock<IBadWordsHandler> mockBadWords;
 
         private List<Message> messages = [new() { Content = "Content", CreationDate = DateTime.Now, Email = "Email", Name = "Name", Username = "Username", Id = Guid.NewGuid() },
                                           new() { Content = "Content", CreationDate = DateTime.Now, Email = "Email", Name = "Name", Username = "Username", Id = Guid.NewGuid() , IsDeleted = true}];
+        private Message withoutBadWords = new() { Content = "Content", CreationDate = DateTime.Now, Email = "Email", Name = "Name", Username = "Username", Id = Guid.NewGuid() };
+        private Message withBadWords = new() { Content = "ContentBADDDDDDDDDD", CreationDate = DateTime.Now, Email = "Email", Name = "Name", Username = "Username", Id = Guid.NewGuid() };
         private readonly Guid missingId = Guid.NewGuid();
-        public HandlerTests()
+        public MessageHandlerTests()
         {
+            mockBadWords = new();
             mockRepository = new();
 
             mockRepository.Setup(m => m.Messages).Returns(messages.AsQueryable());
             mockRepository.Setup(m => m.GetById(messages[0].Id)).Returns(messages[0]);
 
-            handler = new MessageHandler(mockRepository.Object, Mock.Of<IBadWordsHandler>());
+            mockBadWords.Setup(m => m.CheckForBadWords(new List<string>() { withBadWords.Name, withBadWords.Content })).Throws(new BadWordException(""));
+
+            handler = new MessageHandler(mockRepository.Object, mockBadWords.Object);
+        }
+
+        [Fact]
+        public void AddMessageWithoutBadWords()
+        {
+            handler.Insert(withoutBadWords);
+
+            mockRepository.Verify(m => m.Insert(withoutBadWords), Times.Once);
+        }
+
+        [Fact]
+        public void AddMessageWithBadWords()
+        {
+            Assert.Throws<BadWordException>(() => handler.Insert(withBadWords));
         }
 
         [Fact]

--- a/SharedLibrary/Constants.cs
+++ b/SharedLibrary/Constants.cs
@@ -1,0 +1,11 @@
+﻿namespace SharedLibrary
+{
+    public class Constants
+    {
+        public const int MessageNameMaxLength = 100;
+        public const int MessageContentMaxLength = 1000;
+        
+        public const int EmailMaxLength = 256;
+        public const int UsernameMaxLength = 256;
+    }
+}

--- a/SharedLibrary/SharedLibrary.csproj
+++ b/SharedLibrary/SharedLibrary.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
##Changes
-Added a bad words feature (including a controller, handler and repository) which doesn't add a message if there are bad words in it
-Added authorized endpoints for adding/removing bad words

##Unit Tests
-added coverage
-added integration tests for adding a message with bad words in it, for adding/removing bad words
##Logs and Screenshots
-After adding bad words as admin they go to the database
![image](https://github.com/user-attachments/assets/09872d83-c82a-415c-9b1c-092a8d59c645)
-After removing a non existing bad word the response is:
`{
    "title": "Bad word for removal not found.",
    "status": 404
}`
-After removing an existing bad word it reflects in the database:
![image](https://github.com/user-attachments/assets/3aa73eae-c04a-4d6c-b6b2-35520f8059a9)
-When trying to post a message with a bad word in it you get:
`{
    "title": "desolation is a bad word!",
    "status": 406
}`